### PR TITLE
Configure kubeletDir for k0s, k3s, ... flavors not using default k8s path

### DIFF
--- a/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -121,14 +121,14 @@ spec:
     {{- end }}
       volumes:
       - hostPath:
-          path: /var/lib/kubelet/plugins/{{ .Values.storageClassName }}
+          path: {{ .Values.kubeletDir }}/plugins/{{ .Values.storageClassName }}
           type: DirectoryOrCreate
         name: plugin-dir
       - hostPath:
-          path: /var/lib/kubelet/pods
+          path: {{ .Values.kubeletDir }}/pods
           type: Directory
         name: pods-mount-dir
       - hostPath:
-          path: /var/lib/kubelet/plugins_registry
+          path: {{ .Values.kubeletDir }}/plugins_registry
           type: DirectoryOrCreate
         name: registration-dir

--- a/deploy/csi-rclone/values.yaml
+++ b/deploy/csi-rclone/values.yaml
@@ -58,5 +58,6 @@ csiNodepluginRclone:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+kubeletDir: /var/lib/kubelet # Tune if running in k0s, k3s, ...
 kubernetesClusterDomain: cluster.local
 logLevel: NOTICE # Valid levels: DEBUG|INFO|NOTICE|ERROR


### PR DESCRIPTION
With this PR, an helm chart user can instruct to use a different directory for the host kubelet directory.
It is useful for multiple flavors of kubernetes.
openebs and csi-driver-nfs does it as well
https://github.com/openebs/lvm-localpv/blob/develop/deploy/helm/charts/values.yaml#L36-L38