### PR TITLE
chore: do not use CHANGELOG.txt anymore

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Note: The changelog is not used anymore. Please see the releases on the github repository page
+at https://github.com/SwissDataScienceCenter/csi-rclone/releases to see all release notes and
+changelogs.
+
 v0.2.0
 ------
 


### PR DESCRIPTION
Instead we just use the automatically generated release notes on Github.