### PR TITLE
fix: use extra storage class when reading secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,12 @@ This project implements Container Storage Interface (CSI) plugin that allows usi
 
 ## Usage
 
-The easiest way to use this driver is to just create a Persistent Volume Claim (PVC) with the `csi-rclone`
-storage class. Or if you have modified the storage class name in the `values.yaml` file then use the name you have chosen.
-Note that since the storage is backed by an existing cloud storage like S3 or something similar the size 
+The easiest way to use this driver is to just create a Persistent Volume Claim (PVC) with the `csi-rclone-secret-annotation`
+storage class. Or if you have modified the storage class name in the `values.yaml` file then use the name you have chosen with 
+`-secret-annotation` added at the end of the name. The Helm chart creates 2 storage classes for compatibility reasons. The 
+storage class that matches the name in the values file will expect a secret that matches the PVC name to exist in the same namespace
+as the PVC. Whereas the storage class that has the suffix `-secret-annotation` will require the PVC to have the `csi-rclone.dev/secretName` annotation.
+Note that since the storage is backed by an existing cloud storage like S3 or something similar, the size 
 that is requested in the PVC below has no role at all and is completely ignored. It just has to be provided in the PVC specification.
 
 ```yaml
@@ -24,7 +27,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: csi-rclone
+  storageClassName: csi-rclone-secret-annotation
 ```
 
 You have to provide a secret with the rclone configuration. The secret has to have a specific format explained below.
@@ -50,14 +53,13 @@ stringData:
     [giab]
     type = s3
     provider = AWS
-
 ```
 
 ### Skip provisioning and create PV directly
 
 This is more complicated but doable. Here you have to specify the secret name in the CSI parameters.
 Assuming that the secret that contains the configuration is called `csi-rclone-example-secret` and 
-is located in the namespace `csi-rclone-example-secret-namespace`, then the PV specification would look as follows.
+is located in the namespace `csi-rclone-example`, then the PV specification would look as follows.
 
 ```yaml
 apiVersion: v1
@@ -71,10 +73,30 @@ spec:
     storage: 10Gi
   csi:
     driver: csi-rclone
+    volumeHandle: csi-rclone-pv-example  # same as the PersistentVolumeName
+    # For the provisioning to fully work both fields are required even though they both refer to the same secret
+    nodePublishSecretRef:
+      name: csi-rclone-example-secret
+      namespace: csi-rclone-example
     volumeAttributes:
-      nodePublishSecretRef: csi-rclone-example-secret
-      nodePublisSecretRefNamespace: csi-rclone-example-secret-namespace
+      secretName: csi-rclone-example-secret
+      secretNamespace: csi-rclone-example
   persistentVolumeReclaimPolicy: Delete
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pv-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  # If the storage class is not blank then you will get automatic provisioning and the PVC may not be bound
+  # to the selected volume.
+  storageClassName: ""
+  volumeName: "csi-rclone-pv-example"
 ```
 
 ## Installation

--- a/deploy/csi-rclone/templates/csi-rclone-storageclass.yaml
+++ b/deploy/csi-rclone/templates/csi-rclone-storageclass.yaml
@@ -7,6 +7,16 @@ metadata:
 provisioner: {{ .Values.storageClassName }}
 volumeBindingMode: Immediate
 reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClassName }}-secret-annotation
+  labels:
+  {{- include "chart.labels" . | nindent 4 }}
+provisioner: {{ .Values.storageClassName }}
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
 parameters:
   # CreateVolumeRequest.secrets or DeleteVolumeRequest.secrets
   # If creating a PersistentVolume by hand then these are not needed, see below

--- a/pkg/rclone/nodeserver.go
+++ b/pkg/rclone/nodeserver.go
@@ -58,8 +58,12 @@ func (ns *nodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	volumeId := req.GetVolumeId()
 	volumeContext := req.GetVolumeContext()
 	readOnly := req.GetReadonly()
-	secretName := volumeContext["secretName"]
-	secretNamespace := volumeContext["secretNamespace"]
+	secretName, foundSecret := volumeContext["secretName"]
+	secretNamespace, foundSecretNamespace := volumeContext["secretNamespace"]
+
+	if !foundSecret || !foundSecretNamespace {
+		return nil, fmt.Errorf("Cannot find the 'secretName' and/or 'secretNamespace' fields in the volume context. If you are not using automated provisioning you have to specify these values manually in spec.csi.volumeAttributes in your PersistentVolume manifest. If you are using automated provisioning and these values are not found report this as a bug to the developers.")
+	}
 
 	// This is here for compatiblity reasons
 	// If the req.Secrets is empty it means that the old method of passing the secret is used


### PR DESCRIPTION
When secrets are read from annotations automatically then the storage class will not support creating a PVC without the annotations. Therefore we add the option to get the secret from the PVC annotations from a new storage class so that when the old storage class is used things work as before.