### PR TITLE
fix: failing liveness probe

### DIFF
--- a/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -51,7 +51,7 @@ spec:
           name: registration-dir
       - name: liveness-probe
         imagePullPolicy: Always
-        image: registry.k8s.io/sig-storage/livenessprobe:v2.11.0
+        image: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
         args:
         - --csi-address=/plugin/csi.sock
         volumeMounts:


### PR DESCRIPTION
We see often that the rclone driver fails to start back up and it gets stuck in a loop of crashing liveness probe.

The 2.12 changelog for the liveness probe image (published by k8s) https://github.com/kubernetes-csi/livenessprobe/blob/release-2.15/CHANGELOG/CHANGELOG-2.12.md mentions something very much like what we see.

So this should clear up the problem with rclone failing to start.

And if it does not then it is also just a good idea to update the image.