### PR TITLE
build: use devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,4 +20,5 @@
     "containerEnv": {
         "CLUSTER_NAME": "csi-rclone-k8s"
     }
+    // "postCreateCommand": "echo \"user_allow_other\" >> /etc/fuse.conf"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,15 @@
         },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
-			"minikube": "none"
-		},
-        "ghcr.io/devcontainers-extra/features/kind:1": {}
+            "minikube": "none"
+        },
+        "ghcr.io/devcontainers-extra/features/kind:1": {},
+        "./rclone": {
+            "rclone_repository": "https://github.com/rclone/rclone.git",
+            "rclone_ref": "v1.65.2"
+        }
+    },
+    "containerEnv": {
+        "CLUSTER_NAME": "csi-rclone-k8s"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,9 @@
         "ghcr.io/devcontainers-extra/features/apt-packages:1": {
             "packages": "fuse3"
         },
+        "ghcr.io/devcontainers-extra/features/bash-command:1": {
+            "command": "echo \"user_allow_other\" >> /etc/fuse.conf"
+        },
         "ghcr.io/devcontainers/features/docker-in-docker:2": {},
         "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
             "minikube": "none"
@@ -17,8 +20,11 @@
             "rclone_ref": "v1.65.2"
         }
     },
+    "overrideFeatureInstallOrder": [
+        "ghcr.io/devcontainers-extra/features/apt-packages",
+        "ghcr.io/devcontainers-extra/features/bash-command"
+    ],
     "containerEnv": {
         "CLUSTER_NAME": "csi-rclone-k8s"
     }
-    // "postCreateCommand": "echo \"user_allow_other\" >> /etc/fuse.conf"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "CSI rclone devcontainer",
+    "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+    "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/go:1": {},
+        "ghcr.io/devcontainers-extra/features/apt-packages:1": {
+            "packages": "fuse3"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+        "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"minikube": "none"
+		},
+        "ghcr.io/devcontainers-extra/features/kind:1": {}
+    }
+}

--- a/.devcontainer/rclone/devcontainer-feature.json
+++ b/.devcontainer/rclone/devcontainer-feature.json
@@ -1,0 +1,30 @@
+{
+  "id": "rclone",
+  "version": "1.0.0",
+  "name": "A feature adding a custom version of rclone",
+  "postCreateCommand": "rclone --version",
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/go"
+  ],
+  "options": {
+    "rclone_repository": {
+      "type": "string",
+      "description": "rclone repository",
+      "proposals": [
+        "https://github.com/SwissDataScienceCenter/rclone.git",
+        "https://github.com/rclone/rclone.git"
+      ],
+      "default": "https://github.com/rclone/rclone.git"
+    },
+    "rclone_ref": {
+      "type": "string",
+      "description": "git reference",
+      "proposals": [
+        "master",
+        "v1.69.1",
+        "v1.65.2"
+      ],
+      "default": "v1.65.2"
+    }
+  }
+}

--- a/.devcontainer/rclone/install.sh
+++ b/.devcontainer/rclone/install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+USERNAME="${_REMOTE_USER}"
+
+set -ex
+
+echo "Downloading rclone sources from ${RCLONE_REPOSITORY}:${RCLONE_REF}"
+mkdir -p /tmp/rclone
+cd /tmp/rclone
+git clone "${RCLONE_REPOSITORY}"
+cd rclone
+git checkout "${RCLONE_REF}"
+
+echo "Building rclone"
+make rclone
+cd $HOME
+rm -rf /tmp/rclone
+
+# Fix the $GOPATH folder
+chown -R "${USERNAME}:golang" /go
+chmod -R g+r+w /go

--- a/.devcontainer/rclone/install.sh
+++ b/.devcontainer/rclone/install.sh
@@ -19,5 +19,3 @@ rm -rf /tmp/rclone
 # Fix the $GOPATH folder
 chown -R "${USERNAME}:golang" /go
 chmod -R g+r+w /go
-
-echo "user_allow_other" >> /etc/fuse.conf

--- a/.devcontainer/rclone/install.sh
+++ b/.devcontainer/rclone/install.sh
@@ -19,3 +19,5 @@ rm -rf /tmp/rclone
 # Fix the $GOPATH folder
 chown -R "${USERNAME}:golang" /go
 chmod -R g+r+w /go
+
+echo "user_allow_other" >> /etc/fuse.conf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
             helm template -n csi-rclone csi-rclone deploy/csi-rclone > build/kind/csi-rclone-chart.yaml
             KUBECONFIG=build/kube/config kubectl create namespace csi-rclone || true
             KUBECONFIG=build/kube/config kubectl apply -f build/kind/csi-rclone-chart.yaml
-            KUBECONFIG=build/kube/config go test -v ./...
+            KUBECONFIG="$(pwd)/build/kube/config" go test -v ./...
           push: never
           skipContainerUserIdUpdate: false
           cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,9 +25,6 @@ jobs:
     outputs:
       image_repository: ${{ steps.docker_image.outputs.image_repository }}
       image_tag: ${{ steps.docker_image.outputs.image_tag }}
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Docker image metadata
@@ -52,6 +49,11 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "image_repository=$IMAGE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build devcontainer
         uses: devcontainers/ci@v0.3
         continue-on-error: true
@@ -63,6 +65,50 @@ jobs:
           cacheFrom: |
             ${{ steps.docker_image.outputs.image_repository }}:${{ steps.docker_image.outputs.image_tag }}
             ${{ steps.docker_image.outputs.image_repository }}:${{ env.DEVCONTAINER_IMAGE_TAG_MAIN }}
+
+  tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build csi-rclone
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            make build/csi-rclone
+          push: never
+          skipContainerUserIdUpdate: false
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+      - name: Helm check
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            helm lint deploy/csi-rclone
+          push: never
+          skipContainerUserIdUpdate: false
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+      - name: Run tests
+        id: tests
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: |
+            # TODO: move these commands into the Makefile
+            kind delete cluster --name "$CLUSTER_NAME"
+            kind create cluster --name "$CLUSTER_NAME"
+            mkdir -p build/kube
+            kind get kubeconfig --name "$CLUSTER_NAME" > build/kube/config
+            docker buildx build --tag csi-rclone:test --load .
+            kind load docker-image csi-rclone:test --name "$CLUSTER_NAME"
+            mkdir -p build/kind
+            helm template -n csi-rclone csi-rclone deploy/csi-rclone > build/kind/csi-rclone-chart.yaml
+            KUBECONFIG=build/kube/config kubectl create namespace csi-rclone || true
+            KUBECONFIG=build/kube/config kubectl apply -f build/kind/csi-rclone-chart.yaml
+            KUBECONFIG=build/kube/config go test -v ./...
+          push: never
+          skipContainerUserIdUpdate: false
+          cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
+      - name: Print rclone log
+        if: ${{ failure() && steps.tests.conclusion == 'failure' }}
+        run: cat /tmp/rclone.log
 
 # on: 
 #   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,9 @@ jobs:
     outputs:
       image_repository: ${{ steps.docker_image.outputs.image_repository }}
       image_tag: ${{ steps.docker_image.outputs.image_tag }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
       - name: Docker image metadata
@@ -49,11 +52,6 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "image_repository=$IMAGE_REPOSITORY" >> "$GITHUB_OUTPUT"
           echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pre-build devcontainer
         uses: devcontainers/ci@v0.3
         continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,6 +68,8 @@ jobs:
 
   tests:
     runs-on: ubuntu-24.04
+    needs:
+      - build-devcontainer
     steps:
       - uses: actions/checkout@v4
       - name: Build csi-rclone
@@ -109,45 +111,3 @@ jobs:
       - name: Print rclone log
         if: ${{ failure() && steps.tests.conclusion == 'failure' }}
         run: cat /tmp/rclone.log
-
-# on: 
-#   pull_request:
-#     types: [ opened, reopened, synchronize ]
-#     branches:
-#   push:
-#     branches:
-#       - master
-#     tags:
-#       - "v*.*.*"
-# jobs:
-#   tests:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v3
-#       - name: Install fuse
-#         run: |
-#           sudo apt-get update
-#           sudo apt-get install -y fuse3 
-#           sudo bash -c 'echo "user_allow_other" >> /etc/fuse.conf'
-#       - uses: actions/setup-go@v4
-#         with:
-#           go-version: '1.20'
-#       - uses: cachix/install-nix-action@v22
-#         with:
-#           nix_path: nixpkgs=channel:nixos-unstable
-#       - name: Flake check
-#         run: nix flake check
-#       - name: Helm check
-#         run: helm lint deploy/csi-rclone
-#       - name: Run tests
-#         uses: workflow/nix-shell-action@v3.3.0
-#         with:
-#           flakes-from-devshell: true
-#           script: |
-#             init-kind-cluster
-#             local-deploy
-#             get-kind-kubeconfig
-#             go test -v ./...
-#       - name: Print rclone log
-#         if: ${{ failure() }}
-#         run: cat /tmp/rclone.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
-            helm lint deploy/csi-rclone
+            make helm-lint
           push: never
           skipContainerUserIdUpdate: false
           cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}
@@ -93,18 +93,15 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           runCmd: |
-            # TODO: move these commands into the Makefile
-            kind delete cluster --name "$CLUSTER_NAME"
-            kind create cluster --name "$CLUSTER_NAME"
-            mkdir -p build/kube
-            kind get kubeconfig --name "$CLUSTER_NAME" > build/kube/config
-            docker buildx build --tag csi-rclone:test --load .
-            kind load docker-image csi-rclone:test --name "$CLUSTER_NAME"
-            mkdir -p build/kind
-            helm template -n csi-rclone csi-rclone deploy/csi-rclone > build/kind/csi-rclone-chart.yaml
-            KUBECONFIG=build/kube/config kubectl create namespace csi-rclone || true
-            KUBECONFIG=build/kube/config kubectl apply -f build/kind/csi-rclone-chart.yaml
-            KUBECONFIG="$(pwd)/build/kube/config" go test -v ./...
+            make cleanup
+            make kind-delete-cluster
+            make kind-create-cluster
+            make kind-get-kubeconfig
+            make kind-create-namespace
+            make kind-load-docker-image-test
+            make helm-template-test
+            make kind-depoy-test
+            make tests
           push: never
           skipContainerUserIdUpdate: false
           cacheFrom: ${{ needs.build-devcontainer.outputs.image_repository }}:${{ needs.build-devcontainer.outputs.image_tag }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,42 +1,104 @@
 name: Run Tests
-on: 
-  pull_request:
-    types: [ opened, reopened, synchronize ]
-    branches:
+
+on:
   push:
-    branches:
-      - master
-    tags:
-      - "v*.*.*"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  build-devcontainer:
+    runs-on: ubuntu-24.04
+    outputs:
+      image_repository: ${{ steps.docker_image.outputs.image_repository }}
+      image_tag: ${{ steps.docker_image.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Install fuse
+      - uses: actions/checkout@v4
+      - name: Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DEVCONTAINER_REGISTRY }}/${{ env.DEVCONTAINER_IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=cache-pr-,priority=600
+            type=ref,event=branch,prefix=cache-,priority=500
+            type=ref,event=tag,prefix=cache-,priority=500
+          flavor: |
+            latest=false
+      - name: Extract Docker image name
+        id: docker_image
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y fuse3 
-          sudo bash -c 'echo "user_allow_other" >> /etc/fuse.conf'
-      - uses: actions/setup-go@v4
+          IMAGE=$(echo "$IMAGE_TAGS" | cut -d" " -f1)
+          IMAGE_REPOSITORY=$(echo "$IMAGE" | cut -d":" -f1)
+          IMAGE_TAG=$(echo "$IMAGE" | cut -d":" -f2)
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "image_repository=$IMAGE_REPOSITORY" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+      - uses: docker/login-action@v3
         with:
-          go-version: '1.20'
-      - uses: cachix/install-nix-action@v22
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build devcontainer
+        uses: devcontainers/ci@v0.3
+        continue-on-error: true
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Flake check
-        run: nix flake check
-      - name: Helm check
-        run: helm lint deploy/csi-rclone
-      - name: Run tests
-        uses: workflow/nix-shell-action@v3.3.0
-        with:
-          flakes-from-devshell: true
-          script: |
-            init-kind-cluster
-            local-deploy
-            get-kind-kubeconfig
-            go test -v ./...
-      - name: Print rclone log
-        if: ${{ failure() }}
-        run: cat /tmp/rclone.log
+          push: always
+          skipContainerUserIdUpdate: false
+          imageName: ${{ steps.docker_image.outputs.image_repository }}
+          imageTag: ${{ steps.docker_image.outputs.image_tag }}
+          cacheFrom: |
+            ${{ steps.docker_image.outputs.image_repository }}:${{ steps.docker_image.outputs.image_tag }}
+            ${{ steps.docker_image.outputs.image_repository }}:${{ env.DEVCONTAINER_IMAGE_TAG_MAIN }}
+
+# on: 
+#   pull_request:
+#     types: [ opened, reopened, synchronize ]
+#     branches:
+#   push:
+#     branches:
+#       - master
+#     tags:
+#       - "v*.*.*"
+# jobs:
+#   tests:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v3
+#       - name: Install fuse
+#         run: |
+#           sudo apt-get update
+#           sudo apt-get install -y fuse3 
+#           sudo bash -c 'echo "user_allow_other" >> /etc/fuse.conf'
+#       - uses: actions/setup-go@v4
+#         with:
+#           go-version: '1.20'
+#       - uses: cachix/install-nix-action@v22
+#         with:
+#           nix_path: nixpkgs=channel:nixos-unstable
+#       - name: Flake check
+#         run: nix flake check
+#       - name: Helm check
+#         run: helm lint deploy/csi-rclone
+#       - name: Run tests
+#         uses: workflow/nix-shell-action@v3.3.0
+#         with:
+#           flakes-from-devshell: true
+#           script: |
+#             init-kind-cluster
+#             local-deploy
+#             get-kind-kubeconfig
+#             go test -v ./...
+#       - name: Print rclone log
+#         if: ${{ failure() }}
+#         run: cat /tmp/rclone.log

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,11 @@ name: Run Tests
 on:
   push:
 
+env:
+  DEVCONTAINER_REGISTRY: ghcr.io
+  DEVCONTAINER_IMAGE_NAME: ${{ github.repository }}/devcontainer
+  DEVCONTAINER_IMAGE_TAG_MAIN: "cache-main"
+
 defaults:
   run:
     shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _output/
 .vscode
-rclone-build/
+build/
 .direnv/
 result
 kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,24 @@
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+current_dir := $(abspath $(patsubst %/,%,$(dir $(mkfile_path))))
+
 .PHONY: all
 all: help
 
+##@ General
+
+.PHONY: build/csi-rclone
 build/csi-rclone:  ## Build the csi-rclone binary
 	go build -o build/csi-rclone cmd/csi-rclone-plugin/main.go
+
+build-csi-rclone: build/csi-rclone  ## Build the csi-rclone binary
+
+.PHONE: tests
+tests:  ## Run tests
+	KUBECONFIG="$(current_dir)/build/kube/config" go test -v ./...
+
+.PHONY: cleanup
+cleanup:  ## Cleanup the build directory
+	rm -rf build/*
 
 # From the operator sdk Makefile
 # The help target prints out all targets with their descriptions organized
@@ -18,3 +34,51 @@ build/csi-rclone:  ## Build the csi-rclone binary
 .PHONY: help
 help:  ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Docker image
+
+.PHONY: docker-image
+docker-image-test:  ## Build the csi-rclone docker image for tests
+	docker buildx build --tag csi-rclone:latest --load .
+
+##@ Helm
+
+.PHONY: helm-lint
+helm-lint:  ## Lint the helm chart
+	helm lint deploy/csi-rclone
+
+.PHONY: build/kind/csi-rclone-chart.yaml
+build/kind/csi-rclone-chart.yaml:  ## Render the csi-rclone helm charts for tests
+	mkdir -p build/kind
+	helm template -n csi-rclone csi-rclone deploy/csi-rclone > build/kind/csi-rclone-chart.yaml
+
+helm-template-test:  build/kind/csi-rclone-chart.yaml ## Render the csi-rclone helm charts for tests
+
+##@ Kind
+
+.PHONY: kind-create-cluster
+kind-create-cluster:  ## Create the kind cluster
+	kind create cluster --name "${CLUSTER_NAME}"
+
+.PHONY: kind-delete-cluster
+kind-delete-cluster:  ## Delete the kind cluster
+	kind delete cluster --name "${CLUSTER_NAME}"
+
+.PHONY: build/kube/config
+build/kube/config:  ## Get the kubeconfig for the kind cluster
+	mkdir -p build/kube
+	kind get kubeconfig --name "${CLUSTER_NAME}" > build/kube/config
+
+kind-get-kubeconfig: build/kube/config  ## Get the kubeconfig for the kind cluster
+
+.PHONY: kind-create-namespace
+kind-create-namespace:  ## Create the namespace used for tests
+	KUBECONFIG="$(current_dir)/build/kube/config" kubectl create namespace csi-rclone || true
+
+.PHONY: kind-load-docker-image-test
+kind-load-docker-image-test:  docker-image-test ## Load the csi-rclone docker image for tests
+	kind load docker-image csi-rclone:latest --name "${CLUSTER_NAME}"
+
+.PHONY: kind-depoy-test
+kind-depoy-test:  ## Deploy the rendered test chart
+	KUBECONFIG="$(current_dir)/build/kube/config" kubectl apply -f build/kind/csi-rclone-chart.yaml

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build/csi-rclone:  ## Build the csi-rclone binary
 
 build-csi-rclone: build/csi-rclone  ## Build the csi-rclone binary
 
-.PHONE: tests
+.PHONY: tests
 tests:  ## Run tests
 	KUBECONFIG="$(current_dir)/build/kube/config" go test -v ./...
 

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,3 @@ build/csi-rclone:  ## Build the csi-rclone binary
 .PHONY: help
 help:  ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: all
+all: help
+
+build/csi-rclone:  ## Build the csi-rclone binary
+	go build -o build/csi-rclone cmd/csi-rclone-plugin/main.go
+
+# From the operator sdk Makefile
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk command is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+.PHONY: help
+help:  ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-25s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+

--- a/test/sanity_test.go
+++ b/test/sanity_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/SwissDataScienceCenter/csi-rclone/pkg/kube"
@@ -24,19 +25,19 @@ import (
 func getMountDirs() (string, string) {
 	tmpDir := os.TempDir()
 	uuid := uuid.New().String()
-	mntDir := tmpDir + "mount-" + uuid
-	stageDir := tmpDir + "stage-" + uuid
+	mntDir := filepath.Join(tmpDir, "mount-"+uuid)
+	stageDir := filepath.Join(tmpDir, "stage-"+uuid)
 	return mntDir, stageDir
 }
 
 func createSocketDir() (string, error) {
 	uuid := uuid.New().String()
 	tmpDir := os.TempDir()
-	socketDir := tmpDir + "socket-" + uuid
+	socketDir := filepath.Join(tmpDir, "socket-"+uuid)
 	os.RemoveAll(socketDir)
 	err := os.MkdirAll(socketDir, 0700)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return socketDir, nil
 }


### PR DESCRIPTION
Closes #56.

Updates the test GitHub action to use a devcontainer setup.
The new devcontainer can be used for development as well.

Details:
* add devcontainer:
  * `go`
  * `fuse`
  * `rclone` from a `git` repository, so the version can match exactly what is used in the container image
  * `docker-in-docker`, `helm` and `kind`
* the existing `nix` files are left around, but should be removed after this is merged
* the existing test setup is kept:
  * the `go test` run as expected in the devcontainer (locally and in CI/CD)
  * the CSI driver can be installed in `kind`, but there is no actual test (as is the case with the original setup)
* minor fixes on the test file, as the generated path names where incorrect