### PR TITLE
feat: Allow to rotate all nodeplugins at once.

### DIFF
--- a/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -108,6 +108,11 @@ spec:
           name: pods-mount-dir
         - mountPath: /var/lib/rclone
           name: cache-dir
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 100%
+        maxSurge: 100%
     {{- with .Values.csiNodepluginRclone.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}


### PR DESCRIPTION
When we roll-out an update to csi-rclone, currently,
the nodeplugins are deleted and updated one by one:
this makes the roll-out slow for no reason.

The nodeplugins can instead be all deleted and recreated
at the same time for a faster roll-out.
