### PR TITLE
Add extraArgs for rclone daemon configuration

### DIFF
--- a/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rclone.yaml
@@ -84,7 +84,7 @@ spec:
           value: {{ .Values.csiNodepluginRclone.rclone.cache.size | quote }}
         {{- if .Values.csiNodepluginRclone.rclone.extraArgs }}
         - name: EXTRA_ARGS
-          value: {{ join ";" .Values.csiNodepluginRclone.rclone.extraArgs | quote }}
+          value: {{ .Values.csiNodepluginRclone.rclone.extraArgs | toJson | quote }}
         {{- end }}
         {{- with .Values.csiNodepluginRclone.rclone.extraEnv }}
         {{- if . }}

--- a/deploy/csi-rclone/values.yaml
+++ b/deploy/csi-rclone/values.yaml
@@ -64,9 +64,10 @@ csiNodepluginRclone:
       size: 1G
     # Extra arguments to pass to rclone daemon
     extraArgs: []
-    # - "--buffer-size=32M"
-    # - "--transfers=8"
-    # - "--checkers=16"
+    # - name: "buffer-size"
+    #   value: "32M"
+    # - name: "transfers"
+    #   value: "8"
   serviceAccount:
     annotations: {}
   nodeSelector: {}

--- a/pkg/rclone/rclone.go
+++ b/pkg/rclone/rclone.go
@@ -427,10 +427,16 @@ func (r *Rclone) start_daemon() error {
 	// Add any extra arguments from environment variable
 	extraArgs := os.Getenv("EXTRA_ARGS")
 	if extraArgs != "" {
-		for _, arg := range strings.Split(extraArgs, ";") {
-			arg = strings.TrimSpace(arg)
-			if arg != "" {
-				rclone_args = append(rclone_args, arg)
+		var argList []map[string]string
+		if err := json.Unmarshal([]byte(extraArgs), &argList); err == nil {
+			for _, arg := range argList {
+				if name, exists := arg["name"]; exists && name != "" {
+					if value, hasValue := arg["value"]; hasValue && value != "" {
+						rclone_args = append(rclone_args, fmt.Sprintf("--%s=%s", name, value))
+					} else {
+						rclone_args = append(rclone_args, fmt.Sprintf("--%s", name))
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
 
Adds support for passing custom arguments to the rclone daemon via Helm chart configuration

## Changes

- Added `extraArgs` field to `values.yaml` for configurable rclone daemon arguments
- Updated rclone daemon startup to read and apply extra arguments from `EXTRA_ARGS` environment variable
- Added Helm template support to pass `extraArgs` array to the container
- Added usage examples and documentation comments

## Usage

Users can now configure rclone daemon options through the Helm chart:

```yaml
csiNodepluginRclone:
  rclone:
    extraArgs:
      - "--buffer-size=32M"
      - "--transfers=8"
      - "--checkers=16"
```

## Test plan

- Verify Helm template renders correctly with and without extraArgs
- Test rclone daemon startup with various argument combinations
- Confirm backwards compatibility with existing deployments