### PR TITLE
feat:openshift compatibility

### DIFF
--- a/deploy/csi-rclone/templates/csi-controller-rbac.yaml
+++ b/deploy/csi-rclone/templates/csi-controller-rbac.yaml
@@ -8,6 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.csiControllerRclone.serviceAccount.annotations | nindent 4 }}
 ---
+
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -216,7 +218,6 @@ roleRef:
   kind: ClusterRole
   name: '{{ include "chart.fullname" . }}-external-provisioner-runner'
   apiGroup: rbac.authorization.k8s.io
-
 ---
 # Provisioner must be able to work with endpoints in current namespace
 # if (and only if) leadership election is enabled
@@ -289,3 +290,4 @@ roleRef:
   kind: Role
   name: {{ include "chart.fullname" . }}-external-provisioner-cfg
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/deploy/csi-rclone/templates/csi-controller-rbac.yaml
+++ b/deploy/csi-rclone/templates/csi-controller-rbac.yaml
@@ -7,9 +7,9 @@ metadata:
   {{- include "chart.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.csiControllerRclone.serviceAccount.annotations | nindent 4 }}
----
 
-{{- if .Values.rbac.create -}}
+{{ if .Values.rbac.create -}}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/csi-rclone/templates/csi-driver.yaml
+++ b/deploy/csi-rclone/templates/csi-driver.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.driver.create -}}
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
@@ -10,3 +11,4 @@ spec:
   volumeLifecycleModes:
     - Persistent
     - Ephemeral
+{{- end -}}

--- a/deploy/csi-rclone/templates/csi-nodeplugin-rbac.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rbac.yaml
@@ -8,8 +8,8 @@ metadata:
   annotations:
     {{- toYaml .Values.csiNodepluginRclone.serviceAccount.annotations | nindent 4 }}
 
+{{ if .Values.rbac.create -}}
 ---
-{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/csi-rclone/templates/csi-nodeplugin-rbac.yaml
+++ b/deploy/csi-rclone/templates/csi-nodeplugin-rbac.yaml
@@ -7,7 +7,9 @@ metadata:
   {{- include "chart.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.csiNodepluginRclone.serviceAccount.annotations | nindent 4 }}
+
 ---
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -99,3 +101,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "chart.fullname" . }}-nodeplugin'
   namespace: '{{ .Release.Namespace }}'
+{{- end -}}

--- a/deploy/csi-rclone/templates/csi-rclone-storageclass.yaml
+++ b/deploy/csi-rclone/templates/csi-rclone-storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.storageClass.create -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -26,3 +27,4 @@ parameters:
   # If creating a PersistentVolume by hand then set spec.csi.nodePublishSecretRef.name and spec.csi.NodePublishSecretRef.namespace
   csi.storage.k8s.io/node-publish-secret-name: ${pvc.annotations['csi-rclone.dev/secretName']}
   csi.storage.k8s.io/node-publish-secret-namespace: ${pvc.namespace}
+{{- end -}}

--- a/deploy/csi-rclone/values.yaml
+++ b/deploy/csi-rclone/values.yaml
@@ -1,4 +1,10 @@
 storageClassName: csi-rclone
+rbac:
+  create: true
+driver:
+  create: true
+storageClass:
+  create: true
 csiControllerRclone:
   podAnnotations:
     prometheus.io/scrape: "true"


### PR DESCRIPTION
## Describe your changes

This PR implements the option to disable the creation of resources that requires admin privileges:

- RBAC with CusterRole and ClusterRoleBinding
- CSIDriver
- StorageClass

This allows to separate the admin and non-admin parts to facilitate its deployment on OpenShift.