### PR TITLE
refactor: remove useless security context entries

### DIFF
--- a/deploy/csi-rclone/values.yaml
+++ b/deploy/csi-rclone/values.yaml
@@ -67,10 +67,6 @@ csiNodepluginRclone:
     imagePullPolicy: Always
   rclone:
     containerSecurityContext:
-      allowPrivilegeEscalation: true
-      capabilities:
-        add:
-          - SYS_ADMIN
       privileged: true
     # Extra environment variables for the rclone container
     extraEnv: []


### PR DESCRIPTION
## Describe your changes

This PR removes two entries from the containter security context:
- allowPrivilegeEscalation
- capabilities

Neither is usefull since the container must be run in
privileged mode.

## Links

https://kubernetes-csi.github.io/docs/deploying.html

